### PR TITLE
BREAKING: Use a non-fallible iterator for EventSource

### DIFF
--- a/cqrs-core/CHANGELOG.md
+++ b/cqrs-core/CHANGELOG.md
@@ -1,6 +1,7 @@
 # master
 
-* No changes yet
+* Breaking change to `EventSource::Events` so that the iterated items are no
+  longer results.
 
 # [[0.1.0] 2019-02-01](https://github.com/cq-rs/cqrs/releases/tag/cqrs-core-0.1.0)
 

--- a/cqrs-core/src/store.rs
+++ b/cqrs-core/src/store.rs
@@ -13,7 +13,7 @@ where
     E: AggregateEvent<A>,
 {
     /// Represents the sequence of events read from the event source.
-    type Events: IntoIterator<Item = Result<VersionedEvent<E>, Self::Error>>;
+    type Events: IntoIterator<Item = VersionedEvent<E>>;
 
     /// The error type.
     type Error: CqrsError;

--- a/cqrs-postgres/Cargo.toml
+++ b/cqrs-postgres/Cargo.toml
@@ -13,6 +13,7 @@ edition = "2018"
 cqrs-core = { version = "0.1.0", path = "../cqrs-core"}
 fallible-iterator = "0.1"
 log = "0.4"
+num-traits = "0.2"
 postgres = "0.15"
 serde = "1.0"
 serde_json = "1.0"

--- a/cqrs/src/entity.rs
+++ b/cqrs/src/entity.rs
@@ -216,8 +216,6 @@ where
 
         if let Some(seq_events) = seq_events {
             for seq_event in seq_events {
-                let seq_event = seq_event?;
-
                 aggregate.apply(seq_event.event);
 
                 debug_assert_eq!(Version::Number(seq_event.sequence), aggregate.version);

--- a/cqrs/src/memory.rs
+++ b/cqrs/src/memory.rs
@@ -66,7 +66,7 @@ where
     Hasher: BuildHasher,
 {
     type Error = Void;
-    type Events = Vec<Result<VersionedEvent<E>, Void>>;
+    type Events = Vec<VersionedEvent<E>>;
 
     fn read_events<I>(
         &self,
@@ -84,25 +84,20 @@ where
         let result = stream.map(|stream| {
             let stream = stream.read();
             match (since, max_count) {
-                (Since::BeginningOfStream, None) => stream
-                    .events
-                    .iter()
-                    .map(ToOwned::to_owned)
-                    .map(Ok)
-                    .collect(),
+                (Since::BeginningOfStream, None) => {
+                    stream.events.iter().map(ToOwned::to_owned).collect()
+                }
                 (Since::Event(event_number), None) => stream
                     .events
                     .iter()
                     .skip(event_number.get() as usize)
                     .map(ToOwned::to_owned)
-                    .map(Ok)
                     .collect(),
                 (Since::BeginningOfStream, Some(max_count)) => stream
                     .events
                     .iter()
                     .take(max_count.min(usize::max_value() as u64) as usize)
                     .map(ToOwned::to_owned)
-                    .map(Ok)
                     .collect(),
                 (Since::Event(event_number), Some(max_count)) => stream
                     .events
@@ -110,7 +105,6 @@ where
                     .skip(event_number.get() as usize)
                     .take(max_count.min(usize::max_value() as u64) as usize)
                     .map(ToOwned::to_owned)
-                    .map(Ok)
                     .collect(),
             }
         });

--- a/cqrs/src/trivial.rs
+++ b/cqrs/src/trivial.rs
@@ -51,7 +51,7 @@ where
     E: AggregateEvent<A>,
 {
     type Error = Void;
-    type Events = Empty<Result<VersionedEvent<E>, Void>>;
+    type Events = Empty<VersionedEvent<E>>;
 
     #[inline]
     fn read_events<I>(


### PR DESCRIPTION
Reduce the complexity of the core trait. If we need a trait that allows for more lazy loading and errors in the middle, we can create such an interface in the future.